### PR TITLE
Fixed indent on second constructor line, fixed parameter name

### DIFF
--- a/♥ Hearts/3 - Delphi.pas
+++ b/♥ Hearts/3 - Delphi.pas
@@ -3,6 +3,6 @@ type
   public
     Name: String;
     constructor Create
-          (Name: String);
+      (AName: String);
   end;
 Card:=TCard.Create('2♥');


### PR DESCRIPTION
second lines in delphi are always indented by 2 spaces and if you take the same parameter in the constructor as a variable you should change its name (mostly A*****)

and if there is enough space left on the last line, I would write
Card := TCard.Create('2♥');

(a space before and after :=)
