### PR TITLE
changing Java variable rank to int

### DIFF
--- a/♦ Diamonds/8 - Java.java
+++ b/♦ Diamonds/8 - Java.java
@@ -1,6 +1,6 @@
 import static Suit.*;
 
 public class Card {
-    byte rank = 8;
+    int rank = 8;
     Suit suit = Suit.DIAMONDS;
 }


### PR DESCRIPTION
int makes more sense in terms comparability and readability. If you want to go full Object-oriented, you can use Integer, but this would be a overkill for this.
