### PR TITLE
Updated Go.go and Scala.scala

### DIFF
--- a/♠ Spades/11 - Go.go
+++ b/♠ Spades/11 - Go.go
@@ -1,7 +1,7 @@
-card := 
-  &map[string]
-  interface{} {
-    "rank": 11,
-	   "name": "Jack",
-	   "suit": "spades",
+type Card struct {
+  rank int
+  name string
+  suit string
 }
+
+c := Card{11, "Jack", "spades"}

--- a/♠ Spades/4 - Scala.scala
+++ b/♠ Spades/4 - Scala.scala
@@ -1,5 +1,5 @@
 case class Card(
-  var rank:Int, 
-  var suit:String
+  rank: Int, 
+  suit: String
 )
 val c = Card(4, "spades")


### PR DESCRIPTION
Changed both to use more canonical examples of the languages.
## Scala

`var` statement was not needed
## Go.go

structs are a more canonical way of doing things
