### PR TITLE
Java isn't technically legal

### DIFF
--- a/♦ Diamonds/8 - Java.java
+++ b/♦ Diamonds/8 - Java.java
@@ -1,4 +1,9 @@
-import static Suit.*;
+enum Suit {
+    DIAMONDS,
+    CLUBS,
+    SPADES,
+    HEARTS
+}
 
 public class Card {
     int rank = 8;

--- a/♦ Diamonds/8 - Java.java
+++ b/♦ Diamonds/8 - Java.java
@@ -1,11 +1,7 @@
-enum Suit {
-    DIAMONDS,
-    CLUBS,
-    SPADES,
-    HEARTS
-}
+import deck.Suit;
 
 public class Card {
-    int rank = 8;
-    Suit suit = Suit.DIAMONDS;
+  int rank = 8;
+  Suit suit =
+       Suit.DIAMONDS;
 }


### PR DESCRIPTION
`import static` doesn't work on classes in the default package. There are two ways to fix this:
1. Put both Suit and Card into a package (e.g. deck)
2. Drop the import static

The first doesn't really fit within the size constraints without some pretty funky line wrapping:

```
package deck;
import static deck.Suit.*;

public class Card {
    int rank = 8;
    Suit suit = DIAMONDS;
}
```

Although dropping the empty line, I guess this would fit and isn't _terrible_:

```
package deck;
import static
        deck.Suit.*;
public class Card {
    int rank = 8;
    Suit suit =
        DIAMONDS;
}
```

For the PR I went with the second option even though it makes the card less interesting. I also added the Suit prelude which won't go on the card but does make the file compilable.
